### PR TITLE
Reformat table in antibiotics

### DIFF
--- a/antibiotics.md
+++ b/antibiotics.md
@@ -6,19 +6,19 @@
 
 Prepare 20 mls at a time and aliquot
 
-|   Antibiotic    |               Color                | Abbr | Concentration (mg/ml) |     Solvent     | Stock notes |
-|:---------------:|:----------------------------------:|:----:|:---------------------:|:---------------:|:--|
-|    Kanamycin    |   <font color='PURPLE'>PURPLE</font>   | Kan  |          25           | dH<sub>2</sub>0 | Filter |
-|    Gentamicin    |   <font color='654321'>BROWN</font>   | Gm  |          10           | dH<sub>2</sub>0 | Filter |
-|  Spectinomycin   | <font color='BLACK'>BLACK</font> | Sp  |          40           |  dH<sub>2</sub>0   | Filter  |
-|  Tetracycline   | <font color='Green'>GREEN</font> | Tet  |          10           |  100% ethanol (dH<sub>2</sub>0 if tetracycline HCl)   | Filter if dissolved in dH<sub>2</sub>0. Keep dark (foil wrap) |
-|  Ampicillin   | <font color='Red'>RED</font> | Amp  |          100           |  dH<sub>2</sub>0     | Filter |
-|  Chloramphenicol   | <font color='Yellow'>Yellow</font> | Cam  |         25         |  dH<sub>2</sub>0     | Filter |
+|   Antibiotic    |               Color                | Abbr | Concentration (mg/ml) |                      Solvent                       | Stock notes                                                   |
+|:---------------:|:----------------------------------:|:----:|:---------------------:|:--------------------------------------------------:|:--------------------------------------------------------------|
+|    Kanamycin    | <font color='PURPLE'>PURPLE</font> | Kan  |          25           |                  dH<sub>2</sub>0                   | Filter                                                        |
+|   Gentamicin    | <font color='654321'>BROWN</font>  |  Gm  |          10           |                  dH<sub>2</sub>0                   | Filter                                                        |
+|  Spectinomycin  |  <font color='BLACK'>BLACK</font>  |  Sp  |          40           |                  dH<sub>2</sub>0                   | Filter                                                        |
+|  Tetracycline   |  <font color='Green'>GREEN</font>  | Tet  |          10           | 100% ethanol (dH<sub>2</sub>0 if tetracycline HCl) | Filter if dissolved in dH<sub>2</sub>0. Keep dark (foil wrap) |
+|   Ampicillin    |    <font color='Red'>RED</font>    | Amp  |          100          |                  dH<sub>2</sub>0                   | Filter                                                        |
+| Chloramphenicol | <font color='Yellow'>Yellow</font> | Cam  |          25           |                  dH<sub>2</sub>0                   | Filter                                                        |
 
 
-Note that the dry gentimicin is stored at room temperature, but most dry antibiotics are stored at 4C. 
+Note that the dry gentimicin is stored at room temperature, but most dry antibiotics are stored at 4C.
 
-For each stock aliquot approximately 1.2 ml per 1.5 ml tube and store in `antibiotics box` at -20 °C. 
+For each stock aliquot approximately 1.2 ml per 1.5 ml tube and store in `antibiotics box` at -20 °C.
 Label with colored stripe on lid and concentration (e.g. `50` for 50 mg/ml).
 
 Note that there is additional information about making antibiotic-containing media listed under [`media`](media.md).
@@ -28,4 +28,4 @@ Filter refers to filter sterilizing with 0.22 um filters.
 ## Working concentrations for *E. coli* and *Ralstonia*
 
 These stocks are at 1000x concentration, so add 1/1000th volume for regular use (e.g. 500 ul to 500 ml medium).
-If selecting in a minimal medium, a lower antibiotic concentration may be necessary. 
+If selecting in a minimal medium, a lower antibiotic concentration may be necessary.


### PR DESCRIPTION
Used the Markdown table formatting extension. I right clicked and hit format document.